### PR TITLE
Add beta parameter to v_measure function

### DIFF
--- a/R/measures_clusterings.R
+++ b/R/measures_clusterings.R
@@ -313,6 +313,10 @@ completeness <- function(true, pred) {
 #'    are arbitrary.
 #' @param pred predicted clustering represented as a membership
 #'    vector.
+#' @param beta non-negative weight. A value of 0 assigns no weight to
+#'   completeness (i.e. the measure reduces to homogeneity), while larger
+#'   values assign increasing weight to completeness. A value of 1 weights
+#'   completeness and homogeneity equally.
 #'
 #' @references
 #' Rosenberg, A. and Hirschberg, J. "V-measure: A conditional entropy-based external cluster evaluation measure." _Proceedings of the 2007 Joint Conference on Empirical Methods in Natural Language Processing and Computational Natural Language Learning_ (EMNLP-CoNLL), (2007).
@@ -329,9 +333,9 @@ completeness <- function(true, pred) {
 #' v_measure(true, pred)
 #'
 #' @export
-v_measure <- function(true, pred) {
+v_measure <- function(true, pred, beta=1) {
   ct <- contingency_table_clusters(true, pred)
-  v_measure_ct(ct)
+  v_measure_ct(ct, beta=beta)
 }
 
 
@@ -481,8 +485,8 @@ v_measure_ct <- function(ct, beta=1.0) {
   entropy_true <- entropy_counts(true_counts)
   entropy_pred <- entropy_counts(pred_counts)
   mi <- mutual_info_ct(ct)
-  completeness <- ifelse(entropy_true==0, 1.0, mi / entropy_true)
-  homogeneity <- ifelse(entropy_pred==0, 1.0, mi / entropy_pred)
+  homogeneity <- ifelse(entropy_true==0, 1.0, mi / entropy_true)
+  completeness <- ifelse(entropy_pred==0, 1.0, mi / entropy_pred)
   alpha <- 1/(1 + beta^2)
   1 / (alpha / homogeneity + (1 - alpha) / completeness)
 }

--- a/man/v_measure.Rd
+++ b/man/v_measure.Rd
@@ -4,7 +4,7 @@
 \alias{v_measure}
 \title{V-measure Between Clusterings}
 \usage{
-v_measure(true, pred)
+v_measure(true, pred, beta = 1)
 }
 \arguments{
 \item{true}{ground truth clustering represented as a membership
@@ -14,6 +14,11 @@ are arbitrary.}
 
 \item{pred}{predicted clustering represented as a membership
 vector.}
+
+\item{beta}{non-negative weight. A value of 0 assigns no weight to
+completeness (i.e. the measure reduces to homogeneity), while larger
+values assign increasing weight to completeness. A value of 1 weights
+completeness and homogeneity equally.}
 }
 \description{
 Computes the V-measure between two clusterings, such

--- a/tests/testthat/test-measures_clusterings.R
+++ b/tests/testthat/test-measures_clusterings.R
@@ -96,3 +96,10 @@ for (measure_name in names(measures_to_test)) {
     })
   }
 }
+
+test_that("V-Measure is correct for a simple example when beta != 1", {
+  true <- c(1,1,2,2,2)
+  pred <- c(1,1,1,2,2)
+  expect_equal(v_measure(true, pred, beta = 0), homogeneity(true, pred))
+  expect_equal(v_measure(true, pred, beta = Inf), completeness(true, pred))
+})


### PR DESCRIPTION
The beta parameter was unintentionally omitted. This PR adds the
missing parameter to the function definition and docstring. It also
fixes an error in v_measure_ct, where homogeneity and completeness
were mistakenly swapped. The error will not impact current users
as the computation is correct when beta=1.0. A unit test is also
added.