### PR TITLE
Fix typos: "\cup" replaced by "\cap"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,11 @@ Authors@R: c(
     person(given = "Rebecca",
            family = "Steorts", 
            email = "beka@stat.duke.edu",
-           role = c("aut")))
+           role = c("aut")),
+    person(given = "Olivier",
+           family = "Binette",
+           email = "olivier.binette@gmail.com",
+           role = c("ctb")))
 Maintainer: Neil Marchant <ngmarchant@gmail.com>
 Description: Tools for evaluating link prediction and clustering algorithms 
     with respect to ground truth. Includes efficient implementations of 

--- a/R/measures_pairs.R
+++ b/R/measures_pairs.R
@@ -177,7 +177,7 @@ eval_report_pairs <- function(true_pairs, pred_pairs, num_pairs = NULL, ordered=
 #'   (linked) pairs given a set of _ground truth_ coreferent pairs.
 #'
 #' @details The precision is defined as:
-#'   \deqn{\frac{|T \cup P|}{|P|}}{|T ∩ P|/|P|}
+#'   \deqn{\frac{|T \cap P|}{|P|}}{|T ∩ P|/|P|}
 #'   where \eqn{T} is the set of true coreferent pairs and \eqn{P} is the
 #'   set of predicted coreferent pairs.
 #'
@@ -212,7 +212,7 @@ precision_pairs <- function(true_pairs, pred_pairs, ordered=FALSE) {
 #'   (linked) pairs given a set of _ground truth_ coreferent pairs.
 #'
 #' @details The recall is defined as:
-#'   \deqn{\frac{|T \cup P|}{|T|}}{|T ∩ P|/|T|}
+#'   \deqn{\frac{|T \cap P|}{|T|}}{|T ∩ P|/|T|}
 #'   where \eqn{T} is the set of true coreferent pairs and \eqn{P} is the
 #'   set of predicted coreferent pairs.
 #'
@@ -300,7 +300,7 @@ f_measure_pairs <- function(true_pairs, pred_pairs, beta=1, ordered=FALSE) {
 #'   (linked) pairs given a set of _ground truth_ coreferent pairs.
 #'
 #' @details The specificity is defined as:
-#'   \deqn{\frac{|P' \cup T'|}{|P'|}}{|P' ∩ T'|/|P'|}
+#'   \deqn{\frac{|P' \cap T'|}{|P'|}}{|P' ∩ T'|/|P'|}
 #'   where \eqn{T'} is the set of true non-coreferent pairs, \eqn{P} is the
 #'   set of predicted non-coreferent pairs.
 #'
@@ -337,7 +337,7 @@ specificity_pairs <- function(true_pairs, pred_pairs, num_pairs, ordered=FALSE) 
 #'   (linked) pairs given a set of _ground truth_ coreferent pairs.
 #'
 #' @details The accuracy is defined as:
-#'   \deqn{\frac{|T \cup P| + |T' \cup P'|}{N}}{(|T ∩ P| + |T' ∩ P'|)/N}
+#'   \deqn{\frac{|T \cap P| + |T' \cap P'|}{N}}{(|T ∩ P| + |T' ∩ P'|)/N}
 #'   where:
 #'   * \eqn{T} is the set of true coreferent pairs,
 #'   * \eqn{P} is the set of predicted coreferent pairs,
@@ -379,7 +379,7 @@ accuracy_pairs <- function(true_pairs, pred_pairs, num_pairs, ordered=FALSE) {
 #'   pairs.
 #'
 #' @details The balanced accuracy is defined as:
-#'   \deqn{\frac{\frac{|T \cup P|}{|P|} + \frac{|T' \cup P'|}{|P'|}}{2}}{|T ∩ P|/(2|P|) + |T' ∩ P'|/(2|P'|)}
+#'   \deqn{\frac{\frac{|T \cap P|}{|P|} + \frac{|T' \cap P'|}{|P'|}}{2}}{|T ∩ P|/(2|P|) + |T' ∩ P'|/(2|P'|)}
 #'   where:
 #'   * \eqn{T} is the set of true coreferent pairs,
 #'   * \eqn{P} is the set of predicted coreferent pairs,

--- a/man/accuracy_pairs.Rd
+++ b/man/accuracy_pairs.Rd
@@ -30,7 +30,7 @@ Computes the accuracy of a set of \emph{predicted} coreferent
 }
 \details{
 The accuracy is defined as:
-\deqn{\frac{|T \cup P| + |T' \cup P'|}{N}}{(|T ∩ P| + |T' ∩ P'|)/N}
+\deqn{\frac{|T \cap P| + |T' \cap P'|}{N}}{(|T ∩ P| + |T' ∩ P'|)/N}
   where:
 \itemize{
 \item \eqn{T} is the set of true coreferent pairs,

--- a/man/balanced_accuracy_pairs.Rd
+++ b/man/balanced_accuracy_pairs.Rd
@@ -31,7 +31,7 @@ pairs.
 }
 \details{
 The balanced accuracy is defined as:
-\deqn{\frac{\frac{|T \cup P|}{|P|} + \frac{|T' \cup P'|}{|P'|}}{2}}{|T ∩ P|/(2|P|) + |T' ∩ P'|/(2|P'|)}
+\deqn{\frac{\frac{|T \cap P|}{|P|} + \frac{|T' \cap P'|}{|P'|}}{2}}{|T ∩ P|/(2|P|) + |T' ∩ P'|/(2|P'|)}
   where:
 \itemize{
 \item \eqn{T} is the set of true coreferent pairs,

--- a/man/precision_pairs.Rd
+++ b/man/precision_pairs.Rd
@@ -27,7 +27,7 @@ Computes the precision of a set of \emph{predicted} coreferent
 }
 \details{
 The precision is defined as:
-\deqn{\frac{|T \cup P|}{|P|}}{|T ∩ P|/|P|}
+\deqn{\frac{|T \cap P|}{|P|}}{|T ∩ P|/|P|}
   where \eqn{T} is the set of true coreferent pairs and \eqn{P} is the
 set of predicted coreferent pairs.
 }

--- a/man/recall_pairs.Rd
+++ b/man/recall_pairs.Rd
@@ -30,7 +30,7 @@ Computes the precision of a set of \emph{predicted} coreferent
 }
 \details{
 The recall is defined as:
-\deqn{\frac{|T \cup P|}{|T|}}{|T ∩ P|/|T|}
+\deqn{\frac{|T \cap P|}{|T|}}{|T ∩ P|/|T|}
   where \eqn{T} is the set of true coreferent pairs and \eqn{P} is the
 set of predicted coreferent pairs.
 }

--- a/man/specificity_pairs.Rd
+++ b/man/specificity_pairs.Rd
@@ -30,7 +30,7 @@ Computes the specificity of a set of \emph{predicted} coreferent
 }
 \details{
 The specificity is defined as:
-\deqn{\frac{|P' \cup T'|}{|P'|}}{|P' ∩ T'|/|P'|}
+\deqn{\frac{|P' \cap T'|}{|P'|}}{|P' ∩ T'|/|P'|}
   where \eqn{T'} is the set of true non-coreferent pairs, \eqn{P} is the
 set of predicted non-coreferent pairs.
 }


### PR DESCRIPTION
Fixed minor typos in the definitions of pairwise evaluation metrics: "\cup" has been replaced by "\cap".

For instance, it was previously stated that precision is defined as $\frac{\lvert T **\cup** P\rvert }{\lvert P\rvert}$ where $T$ is the set of true coreferent pairs and $P$ is the set of predicted coreferent pairs.